### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrevilain/ai-sdk-mistral-fim/security/code-scanning/2](https://github.com/alexandrevilain/ai-sdk-mistral-fim/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key at the top level of the workflow file. This will apply the specified permissions to all jobs in the workflow unless overridden at the job level. Since the jobs in this workflow only perform read operations (checking out code, installing dependencies, running tests, linting, and building), the minimal required permission is `contents: read`. This change should be made near the top of the file, after the `name` and before the `on` block, or immediately after the `on` block for clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
